### PR TITLE
Validate blob token before uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ uvicorn main:app --reload --port 8000
 ```bash
 cd ../frontend
 cp .env.local.example .env.local
-# adjust BACKEND_URL if needed
+# in .env.local set BACKEND_URL and BLOB_READ_WRITE_TOKEN
 npm install   # or pnpm i / yarn
 npm run dev
 ```
@@ -62,7 +62,7 @@ Images will appear as:
 - Preview ports **3000** (frontend) and **8000** (backend).
 
 ### 4) Deploy
-- **Frontend**: Connect repo to **Vercel** (recommended for Next.js). Set `BACKEND_URL` in Vercel Project → Settings → Environment Variables to your backend URL.
+  - **Frontend**: Connect repo to **Vercel** (recommended for Next.js). Set `BACKEND_URL` and `BLOB_READ_WRITE_TOKEN` in Vercel Project → Settings → Environment Variables.
 - **Backend**: Deploy your GHCR image to **Render**, **Fly.io**, **Azure App Service**, **AWS App Runner**, or **GCP Cloud Run**. Expose port 8000.
 
 Tip: If you prefer GitHub-only hosting for the UI, GitHub Pages won’t run Next.js server features; use **Vercel** for best results.

--- a/frontend/app/api/upload/route.ts
+++ b/frontend/app/api/upload/route.ts
@@ -46,10 +46,28 @@ export async function POST(request: NextRequest) {
 
     const fileBuffer = await file.arrayBuffer()
 
-    const blob = await put(cleanFilename, fileBuffer, {
-      access: "public",
-      token: process.env.BLOB_READ_WRITE_TOKEN,
-    })
+    const token = process.env.BLOB_READ_WRITE_TOKEN
+    if (!token) {
+      console.error("BLOB_READ_WRITE_TOKEN is not set")
+      return NextResponse.json(
+        { error: "Server misconfiguration: BLOB_READ_WRITE_TOKEN is missing" },
+        { status: 500 },
+      )
+    }
+
+    let blob
+    try {
+      blob = await put(cleanFilename, fileBuffer, {
+        access: "public",
+        token,
+      })
+    } catch (error) {
+      console.error("Blob upload failed:", error)
+      return NextResponse.json(
+        { error: "Upload failed: invalid BLOB_READ_WRITE_TOKEN" },
+        { status: 500 },
+      )
+    }
 
     console.log("[v0] File uploaded successfully:", blob.url)
 


### PR DESCRIPTION
## Summary
- verify `BLOB_READ_WRITE_TOKEN` before invoking Vercel Blob `put`
- return descriptive 500 errors when the token is missing or invalid
- document the `BLOB_READ_WRITE_TOKEN` requirement for local and production setups

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68acfb6c607c8331b861533375066bb6