### PR TITLE
Use sh in devcontainer and add bash to frontend image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "dockerComposeFile": "../docker-compose.yml",
   "service": "frontend",
   "workspaceFolder": "/app",
-  "postCreateCommand": "bash -lc 'cd /workspaces/$(basename $PWD)/frontend && npm install || true'",
+  "postCreateCommand": "sh -lc 'cd /app && npm install'",
   "portsAttributes": {
     "3000": { "label": "Next.js Frontend" },
     "8000": { "label": "FastAPI Backend" }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 
 FROM node:20-alpine
+RUN apk add --no-cache bash
 WORKDIR /app
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
 RUN       if [ -f yarn.lock ]; then yarn --frozen-lockfile;       elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i --frozen-lockfile;       else npm ci; fi || npm install


### PR DESCRIPTION
## Summary
- use sh with correct path in devcontainer postCreateCommand
- install bash in frontend Dockerfile for Bash tooling

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad149a49888331afea5eb74944613f