### PR TITLE
feat: align devcontainer and compose workspace paths

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
   "name": "DWPNxt Combined",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "frontend",
-  "workspaceFolder": "/app",
-  "postCreateCommand": "bash -lc 'cd /workspaces/$(basename $PWD)/frontend && npm install || true'",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "bash -lc 'cd frontend && npm install'",
   "portsAttributes": {
     "3000": { "label": "Next.js Frontend" },
     "8000": { "label": "FastAPI Backend" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     environment:
       - BACKEND_URL=http://backend:8000
     volumes:
-      - ./frontend:/app
-    working_dir: /app
+      - .:/workspace
+    working_dir: /workspace/frontend
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- mount repository root into frontend container at /workspace
- set devcontainer workspace root and adjust npm install command

## Testing
- `python -m json.tool .devcontainer/devcontainer.json`
- `npm --version`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad149d69b0833187b1325efd2f3393