### PR TITLE
chore: update numpy and scikit-learn versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 streamlit==1.38.0
 pandas==2.2.2
-numpy==1.26.4
-scikit-learn==1.4.2
+numpy>=2.0.0
+scikit-learn>=1.5.2
 openpyxl==3.1.2
 plotly==5.22.0
 pyyaml==6.0.1


### PR DESCRIPTION
## Summary
- allow wheels for numpy and scikit-learn by relaxing version pins

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b7d40f8833189ef0314043e87b5