### PR TITLE
Pin numpy version for hdbscan compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 streamlit==1.38.0
 pandas==2.2.2
-numpy>=2.0.0
+numpy==1.26.*
 scikit-learn>=1.5.2
 openpyxl==3.1.2
 plotly==5.22.0


### PR DESCRIPTION
## Summary
- pin numpy to 1.26.x in backend requirements for hdbscan compatibility

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad1fe74e408331a5c006454456d389