### PR TITLE
fix: update frontend working dir in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - BACKEND_URL=http://backend:8000
     volumes:
       - .:/workspace
-    working_dir: /dwpnxt-combined/frontend
+    working_dir: /workspace/frontend
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- fix frontend service working_dir to match mounted volume path

## Testing
- `python - <<'PY'
import yaml, sys
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML parsed successfully')
PY`
- `pre-commit run --files docker-compose.yml` (fail: command not found)
- `npm test` (fail: Missing script "test")
- `docker compose restart frontend` (fail: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad2518f95483318c2e283c40ff1924