### PR TITLE
Install build tools for backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- install build-essential in backend Dockerfile so packages with native extensions (e.g. hdbscan, umap-learn, reportlab) compile if needed

## Testing
- `pytest`
- `docker build -t backend-test backend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68ad251a78788331a84acefca8b00aac