### PR TITLE
Send file blob for analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ docker compose up --build
 ```
 
 ## Endpoints
-- `POST /api/analyze` — form-data with `file`: CSV of tickets. Returns JSON (summary, trends, categories).
+- `POST /api/analyze` — form-data with `file`: CSV of tickets. Returns JSON (summary, trends, categories). Example:
+
+  ```bash
+  curl -F "file=@tickets.csv" http://localhost:3000/api/analyze
+  ```
 - `POST /api/export/xlsx` — same input, returns Excel workbook.
 - `POST /api/export/pdf` — same input, returns a one-pager PDF summary.
 

--- a/frontend/app/analyze/page.tsx
+++ b/frontend/app/analyze/page.tsx
@@ -63,15 +63,14 @@ export default function AnalyzePage() {
         })
       }, 500)
 
+      const fileResponse = await fetch(fileUrl)
+      const blob = await fileResponse.blob()
+      const formData = new FormData()
+      formData.append("file", blob, filename)
+
       const response = await fetch("/api/analyze", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          fileUrl,
-          filename,
-        }),
+        body: formData,
       })
 
       clearInterval(progressInterval)


### PR DESCRIPTION
## Summary
- Send uploaded file as FormData from analyze page instead of passing URL
- Document how to call the analyze endpoint with curl

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acfb6906a8833191d7c2e1b4be5e30