### PR TITLE
Pin FastAPI stack dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ openai>=1.55.3,<2
 httpx<0.28
 yake==0.4.8
 
-fastapi
-uvicorn[standard]
-python-multipart
+# Pin web framework and related server dependencies for reproducible builds
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+python-multipart==0.0.20

--- a/frontend/app/analyze/page.tsx
+++ b/frontend/app/analyze/page.tsx
@@ -24,7 +24,7 @@ interface AnalysisResult {
     Driver: string
     Tickets: number
     Median_AHT: number
-    SLA_Breach_%: number
+    'SLA_Breach_%': number
   }>
 }
 


### PR DESCRIPTION
## Summary
- pin FastAPI, Uvicorn, and python-multipart versions for consistent backend builds

## Testing
- `pip install -r backend/requirements.txt`
- `pip check`
- `pytest`
- `npm --prefix frontend install`
- `npm --prefix frontend run build` *(fails: Failed to fetch `Montserrat` and `Open Sans`)*
- `npm --prefix frontend run lint` *(requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2bdd168c8331a9df269945385925