### PR TITLE
Ensure frontend container installs deps before running dev server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
   "dockerComposeFile": "../docker-compose.yml",
   "service": "frontend",
   "workspaceFolder": "/workspace",
-  "postCreateCommand": "bash -lc 'cd frontend && npm install'",
   "portsAttributes": {
     "3000": { "label": "Next.js Frontend" },
     "8000": { "label": "FastAPI Backend" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   frontend:
     build:
       context: ./frontend
-    command: npm run dev
+    command: bash -lc "npm install && npm run dev"
     environment:
       - BACKEND_URL=http://backend:8000
     volumes:


### PR DESCRIPTION
## Summary
- install Node dependencies in frontend container before starting dev server to prevent Codespaces startup failures
- drop redundant postCreateCommand since npm install happens on container startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb1baa1c88331918dfaf582a3b154