### PR TITLE
Pin Numba stack and add build tooling

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential llvm-13 llvm-13-dev libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,8 @@
 streamlit==1.38.0
 pandas==2.2.2
 numpy==1.26.*
+llvmlite==0.43.*
+numba==0.60.*
 scikit-learn>=1.5.2
 openpyxl==3.1.2
 plotly==5.22.0


### PR DESCRIPTION
## Summary
- pin numba and llvmlite versions in backend requirements
- install llvm-13 and libffi-dev in backend Dockerfile for source builds

## Testing
- `pip install --no-cache-dir -r backend/requirements.txt`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ade1c55cb48331827121bb4e512922