### PR TITLE
chore: install python tooling in frontend image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,12 @@
 
-FROM node:20-alpine
-RUN apk add --no-cache bash
+FROM node:20-bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    bash \
+    python3 \
+    python3-pip \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
 RUN       if [ -f yarn.lock ]; then yarn --frozen-lockfile;       elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i --frozen-lockfile;       else npm ci; fi || npm install


### PR DESCRIPTION
## Summary
- use node:20-bookworm-slim instead of alpine
- install bash, python3, pip, and build tools in frontend image for backend deps

## Testing
- `pip install --dry-run -r backend/requirements.txt`
- `docker build -t test-frontend "$tmpdir"` *(fails: command not found: docker)*
- `npm run build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/...`)*

------
https://chatgpt.com/codex/tasks/task_e_68ade1c792948331adce238b4f3407de