### PR TITLE
Add frontend env example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ uvicorn main:app --reload --port 8000
 ### 2) Start Frontend
 ```bash
 cd ../frontend
-cp .env.local.example .env.local
-# in .env.local set BACKEND_URL and BLOB_READ_WRITE_TOKEN
+cp .env.local.example .env.local  # contains BACKEND_URL and BLOB_READ_WRITE_TOKEN placeholders
+# update .env.local with your values
 npm install   # or pnpm i / yarn
 npm run dev
 ```

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+BACKEND_URL=http://localhost:8000
+BLOB_READ_WRITE_TOKEN=your-blob-read-write-token

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.local.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- add `.env.local.example` with placeholders for `BACKEND_URL` and `BLOB_READ_WRITE_TOKEN`
- update frontend `.gitignore` to keep `.env.local` ignored while committing the example file
- document the env example in the README

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ade1cc216c83319f6c31a1768519a4